### PR TITLE
Updates default settings date format (yyyy-MM-dd)

### DIFF
--- a/nightwatch-tests/simple.js
+++ b/nightwatch-tests/simple.js
@@ -1,12 +1,12 @@
 const url = "http://localhost:8000/examples/simple-nightwatch/index.html";
 const textInputSelector = ".elm-datepicker--input";
 const topLeftDaySelector = ".elm-datepicker--row:first-child .elm-datepicker--day:first-child";
-const errorMsgSelector = "#error"
-const openBtn = "#openpickerbtn"
-const closeBtn = "#closepickerbtn"
-const nextMonthBtn = ".elm-datepicker--next"
-const prevMonthBtn = ".elm-datepicker--prev"
-const monthDiv = ".elm-datepicker--month"
+const errorMsgSelector = "#error";
+const openBtn = "#openpickerbtn";
+const closeBtn = "#closepickerbtn";
+const nextMonthBtn = ".elm-datepicker--next";
+const prevMonthBtn = ".elm-datepicker--prev";
+const monthDiv = ".elm-datepicker--month";
 
 const defaultWait = 1000;
 
@@ -21,7 +21,7 @@ module.exports = {
         client.expect.element(monthDiv).text.to.contain("August");
         client.expect.element(topLeftDaySelector).to.be.present.before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/07/27").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-07-27").before(defaultWait);
 
     },
 
@@ -34,7 +34,7 @@ module.exports = {
         client.expect.element(monthDiv).text.to.contain("June");
         client.expect.element(topLeftDaySelector).to.be.present.before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/01").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-01").before(defaultWait);
 
     },
 
@@ -44,7 +44,7 @@ module.exports = {
         client.click(textInputSelector);
         client.expect.element(topLeftDaySelector).to.be.present.before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-29").before(defaultWait);
         client.end();
     },
 
@@ -55,7 +55,7 @@ module.exports = {
         client.sendKeys(textInputSelector, "1980-01-01");
         client.expect.element(topLeftDaySelector).to.be.present.before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-29").before(defaultWait);
         client.end();
     },
 
@@ -72,7 +72,7 @@ module.exports = {
 
         // now we click on another value, to make sure the input is updated
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1979/12/30").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1979-12-30").before(defaultWait);
         client.expect.element("h1").text.to.equal("Dec 30, 1979");
         client.end();
     },
@@ -98,7 +98,7 @@ module.exports = {
         client.expect.element(errorMsgSelector).to.be.present.before(defaultWait);
         client.expect.element(errorMsgSelector).text.to.contain("Parser error: Expected a date only").before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-29").before(defaultWait);
         client.expect.element(errorMsgSelector).to.not.be.present.before(defaultWait);
         client.end();
     },
@@ -112,7 +112,7 @@ module.exports = {
         client.expect.element(errorMsgSelector).to.be.present.before(defaultWait);
         client.expect.element(errorMsgSelector).text.to.contain("Date disabled: 1980-01-02").before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-29").before(defaultWait);
         client.expect.element(errorMsgSelector).to.not.be.present.before(defaultWait);
         client.end();
     },
@@ -127,7 +127,7 @@ module.exports = {
         client.click(openBtn);
         client.expect.element(topLeftDaySelector).to.be.present.before(defaultWait);
         client.click(topLeftDaySelector);
-        client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+        client.expect.element(textInputSelector).value.to.equal("1969-06-29").before(defaultWait);
         client.expect.element(errorMsgSelector).to.not.be.present.before(defaultWait);
         client.end();
     },

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -1,7 +1,7 @@
 module DatePicker exposing
     ( Msg, DateEvent(..), InputError(..), DatePicker
-    , init, initFromDate, initFromDates, update, view, isOpen, focusedDate
-    , Settings, defaultSettings, getInitialDate, pick, between, moreOrLess, from, to, off, open, close
+    , init, initFromDate, initFromDates, update, view, isOpen, focusedDate, getInitialDate
+    , Settings, defaultSettings, pick, between, moreOrLess, from, to, off, open, close
     )
 
 {-| A customizable date picker component.
@@ -109,7 +109,7 @@ defaultSettings =
         ]
     , isDisabled = always False
     , parser = Date.fromIsoString
-    , dateFormatter = Date.format "yyyy/MM/dd"
+    , dateFormatter = Date.format "yyyy-MM-dd"
     , dayFormatter = formatDay
     , monthFormatter = formatMonth
     , yearFormatter = String.fromInt
@@ -279,6 +279,7 @@ isOpen (DatePicker model) =
 focusedDate : DatePicker -> Maybe Date
 focusedDate (DatePicker model) =
     model.focused
+
 
 {-| Expose the initial date
 


### PR DESCRIPTION
Using the default settings causes a parsing error for text inputs that prevents selecting a date.  Pull request updates the format and fixes tests so that text input works as expected.

Found the workaround in issue #20 but hopefully this prevents future users from tripping on the same bug.
