### PR TITLE
Adding EmptyString to the InputError custom type

### DIFF
--- a/examples/simple-nightwatch/SimpleNightwatch.elm
+++ b/examples/simple-nightwatch/SimpleNightwatch.elm
@@ -73,6 +73,9 @@ update msg ({ date, datePicker } as model) =
                         FailedInput (Disabled d) ->
                             Just <| "Date disabled: " ++ Date.toIsoString d
 
+                        FailedInput (EmptyString) ->
+                            Just <| "Empty string error"
+
                         Picked _ ->
                             Nothing
 

--- a/examples/simple-nightwatch/SimpleNightwatch.elm
+++ b/examples/simple-nightwatch/SimpleNightwatch.elm
@@ -73,8 +73,8 @@ update msg ({ date, datePicker } as model) =
                         FailedInput (Disabled d) ->
                             Just <| "Date disabled: " ++ Date.toIsoString d
 
-                        FailedInput (EmptyString) ->
-                            Just <| "Empty string error"
+                        FailedInput EmptyString ->
+                            Just "Empty string error"
 
                         Picked _ ->
                             Nothing

--- a/nightwatch-tests/simple.js
+++ b/nightwatch-tests/simple.js
@@ -89,6 +89,26 @@ module.exports = {
         client.end();
     },
 
+    'Manually entered empty date strings should be interceptable' : function (client) {
+      client.url(url);
+      client.expect.element(textInputSelector).to.be.present.before(defaultWait);
+      client.click(textInputSelector);
+
+      // enter twice to trigger change event for empty string
+      client.sendKeys(textInputSelector, "x");
+      client.sendKeys(textInputSelector, client.Keys.ENTER);
+      client.expect.element(errorMsgSelector).to.be.present.before(defaultWait);
+      client.expect.element(errorMsgSelector).text.to.contain("Parser error: Expected a date in ISO 8601 format").before(defaultWait);
+      client.sendKeys(textInputSelector, client.Keys.BACK_SPACE);
+      client.sendKeys(textInputSelector, client.Keys.ENTER);
+      client.expect.element(errorMsgSelector).to.be.present.before(defaultWait);
+      client.expect.element(errorMsgSelector).text.to.contain("Empty string").before(defaultWait);
+      client.click(topLeftDaySelector);
+      client.expect.element(textInputSelector).value.to.equal("1969/06/29").before(defaultWait);
+      client.expect.element(errorMsgSelector).to.not.be.present.before(defaultWait);
+      client.end();
+  },
+
     'Manually entered invalid dates should be interceptable' : function (client) {
         client.url(url);
         client.expect.element(textInputSelector).to.be.present.before(defaultWait);

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -360,11 +360,14 @@ update settings msg (DatePicker ({ forceOpen, focused } as model)) =
                 False ->
                     let
                         dateEvent =
-                            case Maybe.withDefault "" model.inputText of
-                                "" ->
-                                    FailedInput <| EmptyString
+                            case model.inputText of
+                                Nothing ->
+                                    FailedInput EmptyString
 
-                                rawInput ->
+                                Just "" ->
+                                    FailedInput EmptyString
+
+                                Just rawInput ->
                                     case settings.parser rawInput of
                                         Ok date ->
                                             if settings.isDisabled date then

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -377,8 +377,7 @@ update settings msg (DatePicker ({ forceOpen, focused } as model)) =
                                                 Picked date
 
                                         Err e ->
-
-                                                FailedInput <| Invalid e
+                                            FailedInput <| Invalid e
                     in
                     ( DatePicker
                         { model

--- a/src/DatePicker.elm
+++ b/src/DatePicker.elm
@@ -1,7 +1,7 @@
 module DatePicker exposing
     ( Msg, DateEvent(..), InputError(..), DatePicker
-    , init, initFromDate, initFromDates, update, view, isOpen, focusedDate
-    , Settings, defaultSettings, getInitialDate, pick, between, moreOrLess, from, to, off, open, close
+    , init, initFromDate, initFromDates, update, view, isOpen, focusedDate, getInitialDate
+    , Settings, defaultSettings, pick, between, moreOrLess, from, to, off, open, close
     )
 
 {-| A customizable date picker component.
@@ -280,6 +280,7 @@ focusedDate : DatePicker -> Maybe Date
 focusedDate (DatePicker model) =
     model.focused
 
+
 {-| Expose the initial date
 
 When you initialize the DatePicker using function `init` the resulting `Cmd Msg` fetches todays date.
@@ -322,6 +323,7 @@ type DateEvent
 -}
 type InputError
     = Invalid String
+    | EmptyString
     | Disabled Date
 
 
@@ -358,16 +360,22 @@ update settings msg (DatePicker ({ forceOpen, focused } as model)) =
                 False ->
                     let
                         dateEvent =
-                            case settings.parser <| Maybe.withDefault "" model.inputText of
-                                Ok date ->
-                                    if settings.isDisabled date then
-                                        FailedInput <| Disabled date
+                            case Maybe.withDefault "" model.inputText of
+                                "" ->
+                                    FailedInput <| EmptyString
 
-                                    else
-                                        Picked date
+                                rawInput ->
+                                    case settings.parser rawInput of
+                                        Ok date ->
+                                            if settings.isDisabled date then
+                                                FailedInput <| Disabled date
 
-                                Err e ->
-                                    FailedInput <| Invalid e
+                                            else
+                                                Picked date
+
+                                        Err e ->
+
+                                                FailedInput <| Invalid e
                     in
                     ( DatePicker
                         { model


### PR DESCRIPTION
Adding a variant to the `InputError` custom type to better support unsetting date from text input.  Based on comments in issue #26.